### PR TITLE
Fixes #16

### DIFF
--- a/src/styles/parts/_tag.scss
+++ b/src/styles/parts/_tag.scss
@@ -47,7 +47,8 @@
 }
 
 .tag-list {
-  span {
+  list-style-type: none;
+  li {
     a {
       text-decoration: none;
       color: $dark-blue;

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -18,12 +18,10 @@ const Tags = ({ pageContext, data }) => {
               const { title, date } = node.frontmatter
               const { slug } = node.fields
               return (
-                <span key={slug}>
+                <li key={slug}>
                   <Link to={slug}>{title}</Link>
-                  <small>
-                    <span> | {date}</span>
-                  </small>
-                </span>
+                  <small> | {date}</small>
+                </li>
               )
             })}
           </ul>


### PR DESCRIPTION
Changes the listing of blog posts for a tag from an inline span to a block level
list element because the listing of posts is contained by an unordered list. Also
adjust the list style of the tag-list CSS to be none to hide the bullet