### PR TITLE
Fixes Issue #18 Pagination Resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ Inspired by [flexible-jekyll](https://github.com/artemsheludko/flexible-jekyll).
 
 Much thanks to these contributors for making this project awesome:
 
+-   [@scottelundgren](https://github.com/scottelundgren)
 -   [@sparky005](https://github.com/sparky005)

--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -51,32 +51,31 @@ class BlogIndex extends React.Component {
               </article>
             )
           })}
-        </div>
-
-        <div className="container">
-          <nav className="pagination" role="pagination">
-            <ul>
-              {!isFirst && (
+          <div className="container">
+            <nav className="pagination" role="pagination">
+              <ul>
+                {!isFirst && (
+                  <p>
+                    <Link to={prevPage} rel="prev" className="newer-posts">
+                      ← Previous Page
+                    </Link>
+                  </p>
+                )}
                 <p>
-                  <Link to={prevPage} rel="prev" className="newer-posts">
-                    ← Previous Page
-                  </Link>
+                  <span className="page-number">
+                    Page {currentPage} of {numPages}
+                  </span>
                 </p>
-              )}
-              <p>
-                <span className="page-number">
-                  Page {currentPage} of {numPages}
-                </span>
-              </p>
-              {!isLast && (
-                <p>
-                  <Link to={nextPage} rel="next" className="older-posts">
-                    Next Page →
-                  </Link>
-                </p>
-              )}
-            </ul>
-          </nav>
+                {!isLast && (
+                  <p>
+                    <Link to={nextPage} rel="next" className="older-posts">
+                      Next Page →
+                    </Link>
+                  </p>
+                )}
+              </ul>
+            </nav>
+          </div>
         </div>
       </DefaultLayout>
     )


### PR DESCRIPTION
The div with class container takes the whole page width because it is outside the div with classes content-box and clear-fix. Therefore the sidebar is covering the container div at full screen where the container div collapses under sidebar at mobile width. I moved the container and pagination div into the container class div in `templates\blog-list.js` so the pagination is now visible at all screen sizes: mobile, tablet and desktop.

<img width="1276" alt="PR - Desktop" src="https://user-images.githubusercontent.com/664278/113456884-6adeb300-93dc-11eb-9572-8ce24bd04679.png">
<img width="728" alt="PR - Tablet" src="https://user-images.githubusercontent.com/664278/113456887-6adeb300-93dc-11eb-9c0c-49ee656f41ec.png">
<img width="450" alt="PR - Mobile" src="https://user-images.githubusercontent.com/664278/113456888-6b774980-93dc-11eb-9264-652b370bef06.png">
