### PR TITLE
Changes ARIA role from pagination to navigation

### DIFF
--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -52,7 +52,7 @@ class BlogIndex extends React.Component {
             )
           })}
           <div className="container">
-            <nav className="pagination" role="pagination">
+            <nav className="pagination" role="navigation">
               <ul>
                 {!isFirst && (
                   <p>


### PR DESCRIPTION
There is no pagination role in the ARIA declaration so a screen reader won't know how to parse it.
Since the pagination helps with scrolling through the content changing the role to navigation.

Fixes #22